### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/script.js
+++ b/script.js
@@ -245,7 +245,7 @@ function calculateSettingAsThemeString({ localStorageTheme, systemSettingDark })
   function displayNotFound(word, definitionDiv) {
       const notFoundCardDiv = document.createElement("div");
       notFoundCardDiv.classList.add("not-found-card");
-      notFoundCardDiv.innerHTML = `Erayga "${word}" lagama helin abwaannada aan hayno.`;
+      notFoundCardDiv.textContent = `Erayga "${word}" lagama helin abwaannada aan hayno.`;
       
       const suggestions = getSuggestions(word);
       


### PR DESCRIPTION
Potential fix for [https://github.com/maktabadda/erey.ga/security/code-scanning/1](https://github.com/maktabadda/erey.ga/security/code-scanning/1)

To fix the issue, the `word` variable should be properly escaped before being inserted into the HTML. This can be achieved by using `textContent` instead of `innerHTML` for inserting plain text, as `textContent` does not interpret the string as HTML. Alternatively, if HTML formatting is required, a utility function can be used to escape special characters (e.g., `<`, `>`, `&`, `"`). In this case, since the string does not require HTML formatting, replacing `innerHTML` with `textContent` is the simplest and safest solution.

The changes will be made in the `displayNotFound` function on line 248 of `script.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
